### PR TITLE
Updates catalog API endpoints and sets them to only use metadataType=rc

### DIFF
--- a/renderer/src/components/EditorPage/Reference/TW/TwNavigation.js
+++ b/renderer/src/components/EditorPage/Reference/TW/TwNavigation.js
@@ -7,6 +7,7 @@ import { SnackBar } from '@/components/SnackBar';
 import * as logger from '../../../../logger';
 import MultiComboBox from '../MultiComboBox';
 import packageInfo from '../../../../../../package.json';
+import { environment } from '../../../../../environment';
 
 export default function TwNavigation({ languageId, referenceResources, setReferenceResources }) {
   const [selected, setSelected] = useState('');
@@ -81,7 +82,7 @@ export default function TwNavigation({ languageId, referenceResources, setRefere
     } else {
       // online
       // get options
-      fetch(`https://git.door43.org/api/catalog/v5/search?subject=Translation%20Words&lang=${languageId}&owner=${owner}`)
+      fetch(`${environment.GITEA_API_ENDPOINT}/catalog/search?metadataType=rc&subject=Translation%20Words&lang=${languageId}&owner=${owner}`)
       .then((res) => res.json())
       .then((meta) => {
         // console.log('meta : ', { meta });

--- a/renderer/src/components/Resources/ResourceUtils/CheckHelpsUpdatePopUp.js
+++ b/renderer/src/components/Resources/ResourceUtils/CheckHelpsUpdatePopUp.js
@@ -11,6 +11,7 @@ import * as logger from '../../../logger';
 import DownloadCreateSBforHelps from './DownloadCreateSBforHelps';
 import { handleDownloadResources } from './createDownloadedResourceSB';
 import Door43Logo from '@/icons/door43.svg';
+import { environment } from '../../../../environment';
 
 // const path = require('path');
 
@@ -40,7 +41,7 @@ const checkHelpsVersionUpdate = async (reference, selectResource) => {
         owner = reference?.value?.meta?.owner;
         }
         if (subject && lang && owner) {
-        fetch(`https://git.door43.org/api/catalog/v5/search?subject=${subject}&lang=${lang}&owner=${owner}`)
+        fetch(`${environment.GITEA_API_ENDPOINT}/catalog/search?metadataType=rc&subject=${subject}&lang=${lang}&owner=${owner}`)
         .then((res) => res.json())
         .then((resultMeta) => {
             // console.log({ resultMeta });

--- a/renderer/src/components/Resources/ResourceUtils/DownloadResourcePopUp.js
+++ b/renderer/src/components/Resources/ResourceUtils/DownloadResourcePopUp.js
@@ -19,6 +19,7 @@ import CustomMultiComboBox from './CustomMultiComboBox';
 import langJson from '../../../lib/lang/langNames.json';
 import { handleDownloadResources } from './createDownloadedResourceSB';
 import * as logger from '../../../logger';
+import { environment } from '../../../../environment';
 
 const subjectTypeArray = {
   bible: [
@@ -107,26 +108,18 @@ function DownloadResourcePopUp({ selectResource, isOpenDonwloadPopUp, setIsOpenD
     logger.debug('DownloadResourcePopUp.js', 'fetching resource as per filter applied');
     setLoading(true);
     // subject = bible and lang = en - if not custom filter or initial loading
-    const baseUrl = 'https://git.door43.org/api/catalog/v5/search';
+    const baseUrl = `${environment.GITEA_API_ENDPOINT}/catalog/search?metadataType=rc`;
     let url = '';
     if (filter) {
       url = `${baseUrl}?`;
       if (selectedLangFilter.length > 0) {
         selectedLangFilter.forEach((row) => {
-          if (url.slice(-1) === '?') {
-            url += `lang=${row?.lc ? row?.lc : row?.code}`;
-          } else {
-            url += `&lang=${row?.lc ? row?.lc : row?.code}`;
-          }
+          url += `&lang=${row?.lc ? row?.lc : row?.code}`;
         });
       }
       if (selectedTypeFilter.length > 0) {
         selectedTypeFilter.forEach((row) => {
-          if (url.slice(-1) === '?') {
-            url += `subject=${row.name}`;
-          } else {
-            url += `&subject=${row.name}`;
-          }
+          url += `&subject=${row.name}`;
         });
       } else {
         // nothing selected default will be bible || obs
@@ -145,10 +138,10 @@ function DownloadResourcePopUp({ selectResource, isOpenDonwloadPopUp, setIsOpenD
       // initial load
       switch (selectResource) {
         case 'bible':
-          url = `${baseUrl}?subject=Bible&lang=en`;
+          url = `${baseUrl}&subject=Bible&lang=en`;
           break;
         case 'obs':
-          url = `${baseUrl}?subject=${subjectTypeArray.obs[0].name}&lang=en`;
+          url = `${baseUrl}&subject=${subjectTypeArray.obs[0].name}&lang=en`;
           break;
         default:
           break;
@@ -159,7 +152,7 @@ function DownloadResourcePopUp({ selectResource, isOpenDonwloadPopUp, setIsOpenD
     if (selectedPreProd) {
       url += '&stage=preprod';
     }
-    // url = 'https://git.door43.org/api/catalog/v5/search?subject=Aligned%20Bible&subject=Bible&lang=en&lang=ml&lang=hi';
+    // url = '${environment.GITEA_API_ENDPOINT}/search?metadataType=rc&subject=Aligned%20Bible&subject=Bible&lang=en&lang=ml&lang=hi';
     const temp_resource = {};
     selectedLangFilter.forEach((langObj) => {
       temp_resource[langObj.lc] = [];

--- a/renderer/src/components/Resources/useFetchTranslationResource.js
+++ b/renderer/src/components/Resources/useFetchTranslationResource.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef */
 import * as logger from '../../logger';
+import { environment } from '../../../environment';
 
 function createData(name, language, owner) {
   return {
@@ -8,7 +9,7 @@ function createData(name, language, owner) {
 }
 export const fetchTranslationResource = async (urlpath, setResource, selectResource, selectedPreProd, snackBarAction) => {
   logger.debug('ResourcesPopUp.js', `fetchTranslationResource :  ${selectResource}`);
-  const baseUrl = 'https://git.door43.org/api/catalog/v5/search?';
+  const baseUrl = `${environment.GITEA_API_ENDPOINT}/catalog/search?metadataType=rc&`;
   let url = `${baseUrl}subject=${urlpath}`;
   if (selectedPreProd) {
     url += '&stage=preprod';


### PR DESCRIPTION
This sets the catalog API endpoints to use the `/api/v1/catalog/search` endpoint rather than the old `/api/catalog/v5/search` endpoint so that it is integrated into Gitea's API v1 paths. 

This also makes it so Scribe only searches for RC v0.2 containers, as it seems that is all it supports at this time. 

If you ever do support published Scripture Burrito repos, please add `&metadataType=sb` to the base URL.