### PR TITLE
Fixing issue with LTR resources displaying as RTL in Reference section

### DIFF
--- a/renderer/src/components/EditorPage/Scribex/ReferenceScribex.jsx
+++ b/renderer/src/components/EditorPage/Scribex/ReferenceScribex.jsx
@@ -85,7 +85,7 @@ export default function ReferenceScribex(props) {
           fontFamily: font || 'sans-serif',
           fontSize: `${fontSize}rem`,
           lineHeight: (fontSize > 1.3) ? 1.5 : '',
-          direction: `${projectScriptureDir === 'RTL' ? 'rtl' : 'auto'}`,
+          // direction: `${projectScriptureDir === 'RTL' ? 'rtl' : 'auto'}`,
         }}
     >
       <ReferenceEditor {..._props} />

--- a/renderer/src/components/EditorPage/Scribex/ReferenceScribex.jsx
+++ b/renderer/src/components/EditorPage/Scribex/ReferenceScribex.jsx
@@ -27,7 +27,6 @@ export default function ReferenceScribex(props) {
   const {
     state: {
       fontSize,
-      projectScriptureDir,
     },
   } = useContext(ReferenceContext);
 
@@ -85,7 +84,6 @@ export default function ReferenceScribex(props) {
           fontFamily: font || 'sans-serif',
           fontSize: `${fontSize}rem`,
           lineHeight: (fontSize > 1.3) ? 1.5 : '',
-          // direction: `${projectScriptureDir === 'RTL' ? 'rtl' : 'auto'}`,
         }}
     >
       <ReferenceEditor {..._props} />


### PR DESCRIPTION
Fixing the issue with LTR Bible resources displaying as RTL in Reference section #205 