### PR TITLE
Updating font-detect-rhl adds ~250 more detectable fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "epitelete": "^0.2.20",
     "epitelete-html": "0.2.20-beta.2",
     "eslint-import-resolver-alias": "^1.1.2",
-    "font-detect-rhl": "1.0.5-1",
+    "font-detect-rhl": "1.0.8",
     "font-list": "^1.4.5",
     "fs-extra": "^10.1.0",
     "get-system-fonts": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9634,10 +9634,10 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.9, fol
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
-font-detect-rhl@1.0.5-1:
-  version "1.0.5-1"
-  resolved "https://registry.yarnpkg.com/font-detect-rhl/-/font-detect-rhl-1.0.5-1.tgz#4a421265df97ee672eb515a7f9cae2853ca860f4"
-  integrity sha512-gIRKZvNHp751pSI2bWk3kl3ybeUYiO8fXlo4xJQldp4Esp4yPkGslArJgEQXyROCBPdqU/kTyvA7eWWyE/y9oQ==
+font-detect-rhl@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/font-detect-rhl/-/font-detect-rhl-1.0.8.tgz#5d9231c1c3d451b6d6ddb430af2d3f5438cbf851"
+  integrity sha512-x54euWvS2l2kuN5jq5tb8dkdX1mDZLLrrFgVgCuMRcvTvIj2HfARNalfY8oiDE8065eG08oKzVwuzK87A5Wujw==
   dependencies:
     prop-types "^15.6.1"
     use-deep-compare "^1.1.0"


### PR DESCRIPTION
Updating font-detect-rhl from v1.0.5-1 to v1.0.8 adds around [250 more fonts](https://github.com/RUN-Collaborations/font-detect-rhl/commit/1991d5ac41add5aafc9ea3965e98838e4315f5e8) to the detectable font list.